### PR TITLE
[WIP] Propagate signing errors

### DIFF
--- a/services/interfaces/external_interfaces.go
+++ b/services/interfaces/external_interfaces.go
@@ -42,7 +42,7 @@ type BlockUtils interface {
 }
 
 type KeyManager interface {
-	SignConsensusMessage(blockHeight primitives.BlockHeight, content []byte) primitives.Signature
+	SignConsensusMessage(blockHeight primitives.BlockHeight, content []byte) (primitives.Signature, error)
 	VerifyConsensusMessage(blockHeight primitives.BlockHeight, content []byte, sender *protocol.SenderSignature) error
 	SignRandomSeed(blockHeight primitives.BlockHeight, content []byte) primitives.RandomSeedSignature
 	VerifyRandomSeed(blockHeight primitives.BlockHeight, content []byte, sender *protocol.SenderSignature) error

--- a/test/builders/messages_builder.go
+++ b/test/builders/messages_builder.go
@@ -18,7 +18,8 @@ func APreprepareMessage(
 	block interfaces.Block) *interfaces.PreprepareMessage {
 
 	messageFactory := messagesfactory.NewMessageFactory(instanceId, keyManager, senderMemberId, 0)
-	return messageFactory.CreatePreprepareMessage(blockHeight, view, block, mocks.CalculateBlockHash(block))
+	result, _ := messageFactory.CreatePreprepareMessage(blockHeight, view, block, mocks.CalculateBlockHash(block))
+	return result
 }
 
 func APrepareMessage(
@@ -30,7 +31,8 @@ func APrepareMessage(
 	block interfaces.Block) *interfaces.PrepareMessage {
 
 	messageFactory := messagesfactory.NewMessageFactory(instanceId, keyManager, senderMemberId, 0)
-	return messageFactory.CreatePrepareMessage(blockHeight, view, mocks.CalculateBlockHash(block))
+	result, _ := messageFactory.CreatePrepareMessage(blockHeight, view, mocks.CalculateBlockHash(block))
+	return result
 }
 
 func ACommitMessage(
@@ -43,7 +45,8 @@ func ACommitMessage(
 	randomSeed uint64) *interfaces.CommitMessage {
 
 	messageFactory := messagesfactory.NewMessageFactory(instanceId, keyManager, senderMemberId, randomSeed)
-	return messageFactory.CreateCommitMessage(blockHeight, view, mocks.CalculateBlockHash(block))
+	result, _ := messageFactory.CreateCommitMessage(blockHeight, view, mocks.CalculateBlockHash(block))
+	return result
 }
 
 func AViewChangeMessage(
@@ -55,7 +58,8 @@ func AViewChangeMessage(
 	preparedMessages *preparedmessages.PreparedMessages) *interfaces.ViewChangeMessage {
 
 	messageFactory := messagesfactory.NewMessageFactory(instanceId, keyManager, senderMemberId, 0)
-	return messageFactory.CreateViewChangeMessage(blockHeight, view, preparedMessages)
+	result, _ := messageFactory.CreateViewChangeMessage(blockHeight, view, preparedMessages)
+	return result
 }
 
 func ANewViewMessage(
@@ -69,5 +73,6 @@ func ANewViewMessage(
 	block interfaces.Block) *interfaces.NewViewMessage {
 
 	messageFactory := messagesfactory.NewMessageFactory(instanceId, keyManager, senderMemberId, 0)
-	return messageFactory.CreateNewViewMessage(blockHeight, view, ppContentBuilder, confirmations, block)
+	result, _ := messageFactory.CreateNewViewMessage(blockHeight, view, ppContentBuilder, confirmations, block)
+	return result
 }

--- a/test/mocks/key_manager_mock.go
+++ b/test/mocks/key_manager_mock.go
@@ -29,9 +29,9 @@ func NewMockKeyManager(memberId primitives.MemberId, rejectedMemberIds ...primit
 	}
 }
 
-func (km *MockKeyManager) SignConsensusMessage(blockHeight primitives.BlockHeight, content []byte) primitives.Signature {
+func (km *MockKeyManager) SignConsensusMessage(blockHeight primitives.BlockHeight, content []byte) (primitives.Signature, error) {
 	str := fmt.Sprintf("SIG|%s|%s|%x", blockHeight, km.myMemberId.KeyForMap(), content)
-	return []byte(str)
+	return []byte(str), nil
 }
 
 func (km *MockKeyManager) VerifyConsensusMessage(blockHeight primitives.BlockHeight, content []byte, sender *protocol.SenderSignature) error {


### PR DESCRIPTION
I have changed the interface of the signer to propagate the errors, but there is a lot of work in handling the message creation failures in various ways.

I do not have enough context to make these decisions.