### PR TITLE
[WIP] Refactor worker loop context allocation

### DIFF
--- a/.idea/runConfigurations/LH_All__no_race__count_10.xml
+++ b/.idea/runConfigurations/LH_All__no_race__count_10.xml
@@ -3,7 +3,7 @@
     <module name="lean-helix-go" />
     <working_directory value="$PROJECT_DIR$/" />
     <go_parameters value="-i" />
-    <parameters value="-test.count=10 -test.parallel=1" />
+    <parameters value="-test.count=10 -test.parallel=1 -test.failfast" />
     <framework value="gotest" />
     <kind value="DIRECTORY" />
     <package value="github.com/orbs-network/lean-helix-go" />

--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,44 @@ module github.com/orbs-network/lean-helix-go
 go 1.12
 
 require (
+	cloud.google.com/go v0.43.0 // indirect
+	github.com/coreos/bbolt v1.3.3 // indirect
+	github.com/coreos/etcd v3.3.13+incompatible // indirect
+	github.com/coreos/go-semver v0.3.0 // indirect
+	github.com/coreos/go-systemd v0.0.0-20190719114852-fd7a80b32e1f // indirect
+	github.com/go-kit/kit v0.9.0 // indirect
+	github.com/gobuffalo/logger v1.0.1 // indirect
+	github.com/gobuffalo/packr/v2 v2.5.2 // indirect
+	github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 // indirect
+	github.com/google/pprof v0.0.0-20190723021845-34ac40c74b70 // indirect
+	github.com/grpc-ecosystem/grpc-gateway v1.9.5 // indirect
+	github.com/kisielk/errcheck v1.2.0 // indirect
+	github.com/kr/pty v1.1.8 // indirect
+	github.com/magiconair/properties v1.8.1 // indirect
+	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/orbs-network/go-mock v0.0.0-20180813130752-890a1ee8d0a1
 	github.com/orbs-network/govnr v0.2.0
-	github.com/orbs-network/membuffers v0.3.0
+	github.com/orbs-network/membuffers v0.3.4
 	github.com/orbs-network/scribe v0.1.0
+	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1
-	github.com/stretchr/testify v1.3.0
+	github.com/prometheus/common v0.6.0 // indirect
+	github.com/prometheus/procfs v0.0.3 // indirect
+	github.com/rogpeppe/fastuuid v1.2.0 // indirect
+	github.com/russross/blackfriday v2.0.0+incompatible // indirect
+	github.com/spf13/afero v1.2.2 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/viper v1.4.0 // indirect
+	github.com/stretchr/objx v0.2.0 // indirect
+	github.com/stretchr/testify v1.4.0
+	github.com/ugorji/go v1.1.7 // indirect
+	go.etcd.io/bbolt v1.3.3 // indirect
+	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4 // indirect
+	golang.org/x/exp v0.0.0-20190718202018-cfdd5522f6f6 // indirect
+	golang.org/x/image v0.0.0-20190703141733-d6a02ce849c9 // indirect
+	golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028 // indirect
+	golang.org/x/net v0.0.0-20190628185345-da137c7871d7 // indirect
+	golang.org/x/sys v0.0.0-20190712062909-fae7ac547cb7 // indirect
+	golang.org/x/tools v0.0.0-20190723021737-8bb11ff117ca // indirect
+	google.golang.org/grpc v1.22.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f // indirect
 	github.com/orbs-network/go-mock v0.0.0-20180813130752-890a1ee8d0a1
 	github.com/orbs-network/govnr v0.2.0
-	github.com/orbs-network/membuffers v0.3.4
+	github.com/orbs-network/membuffers v0.3.2
 	github.com/orbs-network/scribe v0.1.0
 	github.com/pelletier/go-toml v1.4.0 // indirect
 	github.com/pkg/errors v0.8.1

--- a/go.sum
+++ b/go.sum
@@ -161,6 +161,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tallstoat/pbparser v0.2.0/go.mod h1:aUC6W9uQLeAXZkknve8ZDO6InhRYpYHlJ9kvsQh1i2k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
@@ -280,6 +281,7 @@ gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/orbs-network/govnr v0.2.0 h1:Txazgo4Jd29hiARXg6nMqK2pmJA85KeXR+ZjLNy9
 github.com/orbs-network/govnr v0.2.0/go.mod h1:kZctUOFclDbO3Z6w559++l4qh0FPb57XdE5IdOFCbI4=
 github.com/orbs-network/membuffers v0.3.0 h1:EYtF1T/VBsi6DGPVS/Xbcei+Vn86fEJ/jJESFiiAqfg=
 github.com/orbs-network/membuffers v0.3.0/go.mod h1:b6+sJ9+pgca7HHle0e85RDd5zL0Hv360Xec7TGVrGFk=
+github.com/orbs-network/membuffers v0.3.4 h1:CZZDYwrmHZAcBobiRTd4cRjrPSUMEmF+CDhSxI0D83A=
+github.com/orbs-network/membuffers v0.3.4/go.mod h1:M5ABv0m0XBGoJbX+7UKVY02hLF4XhS2SlZVEVABMc6M=
 github.com/orbs-network/pbparser v0.2.0/go.mod h1:WSzcxgH5xzywQm0YSASbD7RcdxBXZgqZaDVK8M+8DJ8=
 github.com/orbs-network/scribe v0.1.0 h1:Kn/EQpifQFae+F7HRIoTIipUsSHZNcfQ3HJOhD/b+8M=
 github.com/orbs-network/scribe v0.1.0/go.mod h1:FmGcbukz5eolO+mqzxwmuy4RF4UEoLfGJIeEDAoGsBU=
@@ -159,6 +161,7 @@ github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoH
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/tallstoat/pbparser v0.2.0/go.mod h1:aUC6W9uQLeAXZkknve8ZDO6InhRYpYHlJ9kvsQh1i2k=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/orbs-network/govnr v0.2.0 h1:Txazgo4Jd29hiARXg6nMqK2pmJA85KeXR+ZjLNy9
 github.com/orbs-network/govnr v0.2.0/go.mod h1:kZctUOFclDbO3Z6w559++l4qh0FPb57XdE5IdOFCbI4=
 github.com/orbs-network/membuffers v0.3.0 h1:EYtF1T/VBsi6DGPVS/Xbcei+Vn86fEJ/jJESFiiAqfg=
 github.com/orbs-network/membuffers v0.3.0/go.mod h1:b6+sJ9+pgca7HHle0e85RDd5zL0Hv360Xec7TGVrGFk=
+github.com/orbs-network/membuffers v0.3.2 h1:dpUJXBTjvFkNputqIjCfBJnAJszZALtfuWcf9hGvg/4=
+github.com/orbs-network/membuffers v0.3.2/go.mod h1:M5ABv0m0XBGoJbX+7UKVY02hLF4XhS2SlZVEVABMc6M=
 github.com/orbs-network/membuffers v0.3.4 h1:CZZDYwrmHZAcBobiRTd4cRjrPSUMEmF+CDhSxI0D83A=
 github.com/orbs-network/membuffers v0.3.4/go.mod h1:M5ABv0m0XBGoJbX+7UKVY02hLF4XhS2SlZVEVABMc6M=
 github.com/orbs-network/pbparser v0.2.0/go.mod h1:WSzcxgH5xzywQm0YSASbD7RcdxBXZgqZaDVK8M+8DJ8=

--- a/mainloop.go
+++ b/mainloop.go
@@ -97,6 +97,8 @@ func (m *MainLoop) runMainLoop(ctx context.Context) *govnr.ForeverHandle {
 }
 
 func (m *MainLoop) run(ctx context.Context) {
+	defer m.worker.interrupt()
+
 	if m.electionScheduler == nil {
 		panic("Election trigger was not configured, cannot run Lean Helix (mainloop.run)")
 	}
@@ -183,11 +185,10 @@ func (m *MainLoop) run(ctx context.Context) {
 	}
 
 	m.logger.Info("LHFLOW LHMSG MAINLOOP DONE STOPPED LISTENING, SHUTDOWN END")
-	m.worker.interrupt()
 }
 
 func (m *MainLoop) sendElectionMessageNonBlocking(ctx context.Context, trigger *interfaces.ElectionTrigger) {
-	elChannel :=  m.worker.electionChannel
+	elChannel := m.worker.electionChannel
 	bufferSize := cap(elChannel)
 	if bufferSize == 0 {
 		panic("electionChannel buffer size must be at least 1")
@@ -207,7 +208,7 @@ func (m *MainLoop) sendElectionMessageNonBlocking(ctx context.Context, trigger *
 }
 
 func (m *MainLoop) sendUpdateMessageNonBlocking(ctx context.Context, blockWithProof *blockWithProof) error {
-	msgChannel :=  m.worker.workerUpdateStateChannel
+	msgChannel := m.worker.workerUpdateStateChannel
 	bufferSize := cap(msgChannel)
 	if bufferSize == 0 {
 		panic("workerUpdateStateChannel buffer size must be at least 1")

--- a/mainloop_test.go
+++ b/mainloop_test.go
@@ -13,11 +13,11 @@ func TestRunEndsAfterGoroutinesEnd(t *testing.T) {
 	defer cancelTimer()
 
 	ctx, cancelGoRoutines := context.WithCancel(context.Background())
-	mainloop := NewLeanHelix(mocks.NewMockConfig(), nil, nil)
-	mainloop.Run(ctx)
+	mainLoop := NewLeanHelix(mocks.NewMockConfigSimple(), nil, nil)
+	mainLoop.Run(ctx)
 	time.Sleep(100 * time.Millisecond) // TODO replace with latch that fires after both goroutines have started?
 	cancelGoRoutines()
-	mainloop.WaitUntilShutdown(shutdownContext)
+	mainLoop.WaitUntilShutdown(shutdownContext)
 
 	select {
 	case <-ctx.Done():
@@ -25,5 +25,4 @@ func TestRunEndsAfterGoroutinesEnd(t *testing.T) {
 	case <-shutdownContext.Done():
 		t.Fatalf("system did not shut down in a timely manner")
 	}
-
 }

--- a/services/interfaces/external_interfaces.go
+++ b/services/interfaces/external_interfaces.go
@@ -15,7 +15,7 @@ import (
 	"time"
 )
 
-type OnCommitCallback func(ctx context.Context, block Block, blockProof []byte)
+type OnCommitCallback func(ctx context.Context, block Block, blockProof []byte) error
 type OnNewConsensusRoundCallback func(ctx context.Context, newHeight primitives.BlockHeight, prevBlock Block, canBeFirstLeader bool)
 type OnUpdateStateCallback func(ctx context.Context, currentHeight primitives.BlockHeight, receivedBlockHeight primitives.BlockHeight)
 type OnElectionCallback func(m metrics.ElectionMetrics)

--- a/services/interfaces/external_interfaces.go
+++ b/services/interfaces/external_interfaces.go
@@ -17,7 +17,6 @@ import (
 
 type OnCommitCallback func(ctx context.Context, block Block, blockProof []byte) error
 type OnNewConsensusRoundCallback func(ctx context.Context, newHeight primitives.BlockHeight, prevBlock Block, canBeFirstLeader bool)
-type OnUpdateStateCallback func(ctx context.Context, currentHeight primitives.BlockHeight, receivedBlockHeight primitives.BlockHeight)
 type OnElectionCallback func(m metrics.ElectionMetrics)
 
 type Config struct {
@@ -65,12 +64,12 @@ type KeyManager interface {
 }
 
 type ElectionTrigger struct {
-	MoveToNextLeader func(ctx context.Context)
+	MoveToNextLeader func()
 	Hv               *state.HeightView
 }
 
 type ElectionScheduler interface {
-	RegisterOnElection(blockHeight primitives.BlockHeight, view primitives.View, cb func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB OnElectionCallback))
+	RegisterOnElection(blockHeight primitives.BlockHeight, view primitives.View, cb func(blockHeight primitives.BlockHeight, view primitives.View, onElectionCB OnElectionCallback))
 	ElectionChannel() chan *ElectionTrigger
 	CalcTimeout(view primitives.View) time.Duration
 	Stop()

--- a/services/leanhelixterm/commits_to_blockproof.go
+++ b/services/leanhelixterm/commits_to_blockproof.go
@@ -12,11 +12,10 @@ import (
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 	"github.com/orbs-network/lean-helix-go/services/logger"
 	"github.com/orbs-network/lean-helix-go/services/termincommittee"
-	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
 	"strings"
 )
 
-func CommitsToProof(log logger.LHLogger, blockHeight primitives.BlockHeight, myMemberId primitives.MemberId, keyManager interfaces.KeyManager, onCommit interfaces.OnCommitCallback) termincommittee.OnInCommitteeCommitCallback {
+func CommitsToProof(log logger.LHLogger, keyManager interfaces.KeyManager, onCommit interfaces.OnCommitCallback) termincommittee.OnInCommitteeCommitCallback {
 	return func(ctx context.Context, block interfaces.Block, commitMessages []*interfaces.CommitMessage) {
 		proof := blockproof.GenerateLeanHelixBlockProof(keyManager, commitMessages)
 		committeeStr := commitMessagesToCommitteeMemberIdsStr(commitMessages)

--- a/services/leanhelixterm/consensus_messages_filter.go
+++ b/services/leanhelixterm/consensus_messages_filter.go
@@ -7,7 +7,6 @@
 package leanhelixterm
 
 import (
-	"context"
 	"fmt"
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 	"github.com/orbs-network/lean-helix-go/services/randomseed"
@@ -26,17 +25,17 @@ func NewConsensusMessagesFilter(handler TermMessagesHandler, keyManager interfac
 	return &ConsensusMessagesFilter{handler, keyManager, randomSeed}
 }
 
-func (mp *ConsensusMessagesFilter) HandleConsensusMessage(ctx context.Context, message interfaces.ConsensusMessage) error {
+func (mp *ConsensusMessagesFilter) HandleConsensusMessage(message interfaces.ConsensusMessage) error {
 	if mp.handler == nil {
 		return errors.Errorf("Out of committee - ignoring message %s H=%d V=%d", message.MessageType(), message.BlockHeight(), message.View())
 	}
 
 	switch message := message.(type) {
 	case *interfaces.PreprepareMessage:
-		mp.handler.HandlePrePrepare(ctx, message)
+		mp.handler.HandlePrePrepare(message)
 
 	case *interfaces.PrepareMessage:
-		mp.handler.HandlePrepare(ctx, message)
+		mp.handler.HandlePrepare(message)
 
 	case *interfaces.CommitMessage:
 		senderSignature := (&protocol.SenderSignatureBuilder{
@@ -48,13 +47,13 @@ func (mp *ConsensusMessagesFilter) HandleConsensusMessage(ctx context.Context, m
 		if err := mp.keyManager.VerifyRandomSeed(message.BlockHeight(), randomSeedBytes, senderSignature); err != nil {
 			return errors.Wrapf(err, "Failed in VerifyRandomSeed()")
 		}
-		mp.handler.HandleCommit(ctx, message)
+		mp.handler.HandleCommit(message)
 
 	case *interfaces.ViewChangeMessage:
-		mp.handler.HandleViewChange(ctx, message)
+		mp.handler.HandleViewChange(message)
 
 	case *interfaces.NewViewMessage:
-		mp.handler.HandleNewView(ctx, message)
+		mp.handler.HandleNewView(message)
 
 	default:
 		panic(fmt.Sprintf("unknown message type: %T", message))

--- a/services/leanhelixterm/consensus_messages_filter_test.go
+++ b/services/leanhelixterm/consensus_messages_filter_test.go
@@ -72,11 +72,17 @@ func TestProcessingAMessage(t *testing.T) {
 		require.Equal(t, 0, len(messagesHandler.HistoryNV))
 		require.Equal(t, 0, len(messagesHandler.HistoryVC))
 
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
+		err1 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
+		err2 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
+		err3 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
+		err4 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
+		err5 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
+
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.NoError(t, err3)
+		require.NoError(t, err4)
+		require.NoError(t, err5)
 
 		require.Equal(t, 1, len(messagesHandler.HistoryPP))
 		require.Equal(t, 1, len(messagesHandler.HistoryP))
@@ -98,10 +104,12 @@ func TestFilteringACommitWithBadSeed(t *testing.T) {
 
 		require.Equal(t, 0, len(messagesHandler.HistoryC))
 
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(goodCommit))
+		err := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(goodCommit))
+		require.NoError(t, err)
 		require.Equal(t, 1, len(messagesHandler.HistoryC))
 
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(badCommit))
+		err = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(badCommit))
+		require.NoError(t, err)
 		require.Equal(t, 1, len(messagesHandler.HistoryC)) // still on 1
 	})
 }
@@ -118,12 +126,18 @@ func TestNotSendingMessagesWhenTheHandlerWasNotSet(t *testing.T) {
 		vcm := GenerateViewChangeMessage(instanceId, 10, 20, "Sender MemberId")
 		nvm := GenerateNewViewMessage(instanceId, 10, 20, "Sender MemberId")
 
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
-		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
+		err1 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
+		err2 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
+		err3 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
+		err4 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
+		err5 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
 
+		require.NoError(t, err1)
+		require.NoError(t, err2)
+		require.NoError(t, err3)
+		require.NoError(t, err4)
+		require.NoError(t, err5)
+		
 		// expect that we don't panic
 	})
 }

--- a/services/leanhelixterm/consensus_messages_filter_test.go
+++ b/services/leanhelixterm/consensus_messages_filter_test.go
@@ -104,12 +104,10 @@ func TestFilteringACommitWithBadSeed(t *testing.T) {
 
 		require.Equal(t, 0, len(messagesHandler.HistoryC))
 
-		err := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(goodCommit))
-		require.NoError(t, err)
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(goodCommit))
 		require.Equal(t, 1, len(messagesHandler.HistoryC))
 
-		err = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(badCommit))
-		require.NoError(t, err)
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(badCommit))
 		require.Equal(t, 1, len(messagesHandler.HistoryC)) // still on 1
 	})
 }
@@ -126,18 +124,12 @@ func TestNotSendingMessagesWhenTheHandlerWasNotSet(t *testing.T) {
 		vcm := GenerateViewChangeMessage(instanceId, 10, 20, "Sender MemberId")
 		nvm := GenerateNewViewMessage(instanceId, 10, 20, "Sender MemberId")
 
-		err1 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
-		err2 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
-		err3 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
-		err4 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
-		err5 := consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
+		_ = consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
 
-		require.NoError(t, err1)
-		require.NoError(t, err2)
-		require.NoError(t, err3)
-		require.NoError(t, err4)
-		require.NoError(t, err5)
-		
 		// expect that we don't panic
 	})
 }

--- a/services/leanhelixterm/consensus_messages_filter_test.go
+++ b/services/leanhelixterm/consensus_messages_filter_test.go
@@ -72,11 +72,11 @@ func TestProcessingAMessage(t *testing.T) {
 		require.Equal(t, 0, len(messagesHandler.HistoryNV))
 		require.Equal(t, 0, len(messagesHandler.HistoryVC))
 
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(ppm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(pm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(cm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(vcm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(nvm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
 
 		require.Equal(t, 1, len(messagesHandler.HistoryPP))
 		require.Equal(t, 1, len(messagesHandler.HistoryP))
@@ -98,10 +98,10 @@ func TestFilteringACommitWithBadSeed(t *testing.T) {
 
 		require.Equal(t, 0, len(messagesHandler.HistoryC))
 
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(goodCommit))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(goodCommit))
 		require.Equal(t, 1, len(messagesHandler.HistoryC))
 
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(badCommit))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(badCommit))
 		require.Equal(t, 1, len(messagesHandler.HistoryC)) // still on 1
 	})
 }
@@ -118,11 +118,11 @@ func TestNotSendingMessagesWhenTheHandlerWasNotSet(t *testing.T) {
 		vcm := GenerateViewChangeMessage(instanceId, 10, 20, "Sender MemberId")
 		nvm := GenerateNewViewMessage(instanceId, 10, 20, "Sender MemberId")
 
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(ppm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(pm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(cm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(vcm))
-		consensusMessagesFilter.HandleConsensusMessage(ctx, interfaces.ToConsensusMessage(nvm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(ppm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(pm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(cm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(vcm))
+		consensusMessagesFilter.HandleConsensusMessage(interfaces.ToConsensusMessage(nvm))
 
 		// expect that we don't panic
 	})

--- a/services/leanhelixterm/leanhelix_term.go
+++ b/services/leanhelixterm/leanhelix_term.go
@@ -47,7 +47,7 @@ func NewLeanHelixTerm(ctx context.Context, log logger.LHLogger, config *interfac
 		return termNotInCommittee(randomSeed, config)
 	}
 
-	termInCommittee := termincommittee.NewTermInCommittee(ctx, log, config, state, messageFactory, electionTrigger, committeeMembers, prevBlock, canBeFirstLeader, CommitsToProof(log, blockHeight, myMemberId, config.KeyManager, onCommit))
+	termInCommittee := termincommittee.NewTermInCommittee(log, config, state, messageFactory, electionTrigger, committeeMembers, prevBlock, canBeFirstLeader, CommitsToProof(log, config.KeyManager, onCommit))
 	return &LeanHelixTerm{
 		ConsensusMessagesFilter: NewConsensusMessagesFilter(termInCommittee, config.KeyManager, randomSeed),
 		termInCommittee:         termInCommittee,
@@ -55,7 +55,7 @@ func NewLeanHelixTerm(ctx context.Context, log logger.LHLogger, config *interfac
 }
 
 func requestOrderedCommittee(s *state.State, blockHeight primitives.BlockHeight, randomSeed uint64, config *interfaces.Config) ([]primitives.MemberId, error) {
-	ctx, err := s.ViewContexts.ActiveFor(state.NewHeightView(blockHeight, 0))
+	ctx, err := s.Contexts.For(state.NewHeightView(blockHeight, 0))
 	if err != nil {
 		return nil, err
 	}

--- a/services/leanhelixterm/leanhelix_term.go
+++ b/services/leanhelixterm/leanhelix_term.go
@@ -33,26 +33,43 @@ func NewLeanHelixTerm(ctx context.Context, log logger.LHLogger, config *interfac
 	myMemberId := config.Membership.MyMemberId()
 	messageFactory := messagesfactory.NewMessageFactory(config.InstanceId, config.KeyManager, myMemberId, randomSeed)
 
-	committeeMembers, err := config.Membership.RequestOrderedCommittee(ctx, blockHeight, randomSeed)
+	committeeMembers, err := requestOrderedCommittee(state, blockHeight, randomSeed, config)
 	if err != nil {
-		committeeMembers = nil // this will make sure isParticipating will be false (should be happening on system shutdown only)
-		log.Info("ERROR RECEIVING COMMITTEE: H=%d, prevBlockProof=%s, randomSeed=%d, members=%s error=%s", blockHeight, printShortBlockProofBytes(prevBlockProofBytes), randomSeed, termincommittee.ToCommitteeMembersStr(committeeMembers), err)
+		log.Info("OUT OF COMMITTEE WITH ERROR RECEIVING COMMITTEE: H=%d, prevBlockProof=%s, randomSeed=%d, error=%s", blockHeight, printShortBlockProofBytes(prevBlockProofBytes), randomSeed, err)
+		return termNotInCommittee(randomSeed, config)
 	}
 
 	isParticipating := isParticipatingInCommittee(myMemberId, committeeMembers)
 	log.Debug("RECEIVED COMMITTEE: H=%d, prevBlockProof=%s, randomSeed=%d, members=%s, isParticipating=%t", blockHeight, printShortBlockProofBytes(prevBlockProofBytes), randomSeed, termincommittee.ToCommitteeMembersStr(committeeMembers), isParticipating)
-	if isParticipating {
-		termInCommittee := termincommittee.NewTermInCommittee(ctx, log, config, state, messageFactory, electionTrigger, committeeMembers, prevBlock, canBeFirstLeader, CommitsToProof(log, blockHeight, myMemberId, config.KeyManager, onCommit))
-		return &LeanHelixTerm{
-			ConsensusMessagesFilter: NewConsensusMessagesFilter(termInCommittee, config.KeyManager, randomSeed),
-			termInCommittee:         termInCommittee,
-		}
-	} else {
+
+	if !isParticipating {
 		log.Info("OUT OF COMMITTEE: H=%d, prevBlockProof=%s, randomSeed=%d, members=%s, isParticipating=%t", blockHeight, printShortBlockProofBytes(prevBlockProofBytes), randomSeed, termincommittee.ToCommitteeMembersStr(committeeMembers), isParticipating)
-		return &LeanHelixTerm{
-			ConsensusMessagesFilter: NewConsensusMessagesFilter(nil, config.KeyManager, randomSeed),
-			termInCommittee:         nil,
-		}
+		return termNotInCommittee(randomSeed, config)
+	}
+
+	termInCommittee := termincommittee.NewTermInCommittee(ctx, log, config, state, messageFactory, electionTrigger, committeeMembers, prevBlock, canBeFirstLeader, CommitsToProof(log, blockHeight, myMemberId, config.KeyManager, onCommit))
+	return &LeanHelixTerm{
+		ConsensusMessagesFilter: NewConsensusMessagesFilter(termInCommittee, config.KeyManager, randomSeed),
+		termInCommittee:         termInCommittee,
+	}
+}
+
+func requestOrderedCommittee(s *state.State, blockHeight primitives.BlockHeight, randomSeed uint64, config *interfaces.Config) ([]primitives.MemberId, error) {
+	ctx, err := s.ViewContexts.ActiveFor(state.NewHeightView(blockHeight, 0))
+	if err != nil {
+		return nil, err
+	}
+	committeeMembers, err := config.Membership.RequestOrderedCommittee(ctx, blockHeight, randomSeed)
+	if err != nil {
+		return nil, err
+	}
+	return committeeMembers, nil
+}
+
+func termNotInCommittee(randomSeed uint64, config *interfaces.Config) *LeanHelixTerm {
+	return &LeanHelixTerm{
+		ConsensusMessagesFilter: NewConsensusMessagesFilter(nil, config.KeyManager, randomSeed),
+		termInCommittee:         nil,
 	}
 }
 

--- a/services/leanhelixterm/term_messages_handler.go
+++ b/services/leanhelixterm/term_messages_handler.go
@@ -7,14 +7,13 @@
 package leanhelixterm
 
 import (
-	"context"
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 )
 
 type TermMessagesHandler interface {
-	HandlePrePrepare(ctx context.Context, ppm *interfaces.PreprepareMessage)
-	HandlePrepare(ctx context.Context, pm *interfaces.PrepareMessage)
-	HandleViewChange(ctx context.Context, vcm *interfaces.ViewChangeMessage)
-	HandleCommit(ctx context.Context, cm *interfaces.CommitMessage)
-	HandleNewView(ctx context.Context, nvm *interfaces.NewViewMessage)
+	HandlePrePrepare(ppm *interfaces.PreprepareMessage)
+	HandlePrepare(pm *interfaces.PrepareMessage)
+	HandleViewChange(vcm *interfaces.ViewChangeMessage)
+	HandleCommit(cm *interfaces.CommitMessage)
+	HandleNewView(nvm *interfaces.NewViewMessage)
 }

--- a/services/rawmessagesfilter/consensus_messages_handler.go
+++ b/services/rawmessagesfilter/consensus_messages_handler.go
@@ -7,10 +7,9 @@
 package rawmessagesfilter
 
 import (
-	"context"
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 )
 
 type ConsensusMessagesHandler interface {
-	HandleConsensusMessage(ctx context.Context, message interfaces.ConsensusMessage) error
+	HandleConsensusMessage(message interfaces.ConsensusMessage) error
 }

--- a/services/rawmessagesfilter/test/consensus_message_filter_test.go
+++ b/services/rawmessagesfilter/test/consensus_message_filter_test.go
@@ -63,8 +63,8 @@ func GenerateNewViewMessage(instanceId primitives.InstanceId, blockHeight primit
 func TestGettingAMessage(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		instanceId := primitives.InstanceId(rand.Uint64())
-		state := mocks.NewMockState().WithHeightView(10, 20)
-		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
+		mockState := mocks.NewMockState().WithHeightView(10, 20)
+		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(mockState.State), mockState.State)
 		messagesHandler := NewTermMessagesHandlerMock()
 		filter.ConsumeCacheMessages(messagesHandler)
 
@@ -89,8 +89,8 @@ func TestGettingAMessage(t *testing.T) {
 func TestFilterMessagesFromThePast(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		instanceId := primitives.InstanceId(rand.Uint64())
-		state := mocks.NewMockState().WithHeightView(10, 0)
-		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
+		mockState := mocks.NewMockState().WithHeightView(10, 0)
+		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(mockState.State), mockState.State)
 		messagesHandler := NewTermMessagesHandlerMock()
 		filter.ConsumeCacheMessages(messagesHandler)
 
@@ -108,8 +108,8 @@ func TestFilterMessagesFromThePast(t *testing.T) {
 
 func TestFilterMessagesWithBadInstanceId(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
-		state := mocks.NewMockState().WithHeightView(10, 0)
-		filter := rawmessagesfilter.NewConsensusMessageFilter(777, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
+		mockState := mocks.NewMockState().WithHeightView(10, 0)
+		filter := rawmessagesfilter.NewConsensusMessageFilter(777, primitives.MemberId("My MemberId"), testLogger(mockState.State), mockState.State)
 		messagesHandler := NewTermMessagesHandlerMock()
 		filter.ConsumeCacheMessages(messagesHandler)
 
@@ -128,8 +128,8 @@ func TestFilterMessagesWithBadInstanceId(t *testing.T) {
 func TestCacheMessagesFromTheFuture(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		instanceId := primitives.InstanceId(rand.Uint64())
-		state := mocks.NewMockState().WithHeightView(10, 0)
-		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
+		mockState := mocks.NewMockState().WithHeightView(10, 0)
+		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(mockState.State), mockState.State)
 		messagesHandler := NewTermMessagesHandlerMock()
 		filter.ConsumeCacheMessages(messagesHandler)
 
@@ -148,8 +148,8 @@ func TestCacheMessagesFromTheFuture(t *testing.T) {
 func TestFilterMessagesWithMyMemberId(t *testing.T) {
 	test.WithContext(func(ctx context.Context) {
 		instanceId := primitives.InstanceId(rand.Uint64())
-		state := mocks.NewMockState().WithHeightView(10, 0)
-		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
+		mockState := mocks.NewMockState().WithHeightView(10, 0)
+		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(mockState.State), mockState.State)
 		messagesHandler := NewTermMessagesHandlerMock()
 		filter.ConsumeCacheMessages(messagesHandler)
 

--- a/services/rawmessagesfilter/test/consensus_message_filter_test.go
+++ b/services/rawmessagesfilter/test/consensus_message_filter_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func testLogger(state *state.State) L.LHLogger {
-	return L.NewLhLogger(mocks.NewMockConfig(), state)
+	return L.NewLhLogger(mocks.NewMockConfigSimple(), state)
 }
 
 func GeneratePreprepareMessage(instanceId primitives.InstanceId, blockHeight primitives.BlockHeight, view primitives.View, senderMemberIdStr string) *interfaces.ConsensusRawMessage {

--- a/services/rawmessagesfilter/test/consensus_message_filter_test.go
+++ b/services/rawmessagesfilter/test/consensus_message_filter_test.go
@@ -66,7 +66,7 @@ func TestGettingAMessage(t *testing.T) {
 		state := mocks.NewMockState().WithHeightView(10, 20)
 		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
 		messagesHandler := NewTermMessagesHandlerMock()
-		filter.ConsumeCacheMessages(ctx, messagesHandler)
+		filter.ConsumeCacheMessages(messagesHandler)
 
 		ppm := GeneratePreprepareMessage(instanceId, 10, 20, "Sender MemberId")
 		pm := GeneratePrepareMessage(instanceId, 10, 20, "Sender MemberId")
@@ -76,11 +76,11 @@ func TestGettingAMessage(t *testing.T) {
 
 		require.Equal(t, 0, len(messagesHandler.history))
 
-		filter.HandleConsensusRawMessage(ctx, ppm)
-		filter.HandleConsensusRawMessage(ctx, pm)
-		filter.HandleConsensusRawMessage(ctx, cm)
-		filter.HandleConsensusRawMessage(ctx, vcm)
-		filter.HandleConsensusRawMessage(ctx, nvm)
+		filter.HandleConsensusRawMessage(ppm)
+		filter.HandleConsensusRawMessage(pm)
+		filter.HandleConsensusRawMessage(cm)
+		filter.HandleConsensusRawMessage(vcm)
+		filter.HandleConsensusRawMessage(nvm)
 
 		require.Equal(t, 5, len(messagesHandler.history))
 	})
@@ -92,15 +92,15 @@ func TestFilterMessagesFromThePast(t *testing.T) {
 		state := mocks.NewMockState().WithHeightView(10, 0)
 		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
 		messagesHandler := NewTermMessagesHandlerMock()
-		filter.ConsumeCacheMessages(ctx, messagesHandler)
+		filter.ConsumeCacheMessages(messagesHandler)
 
 		messageFromThePast := GeneratePreprepareMessage(instanceId, 9, 20, "Sender MemberId")
 		messageFromThePresent := GeneratePreprepareMessage(instanceId, 10, 20, "Sender MemberId")
 
 		require.Equal(t, 0, len(messagesHandler.history))
 
-		filter.HandleConsensusRawMessage(ctx, messageFromThePast)
-		filter.HandleConsensusRawMessage(ctx, messageFromThePresent)
+		filter.HandleConsensusRawMessage(messageFromThePast)
+		filter.HandleConsensusRawMessage(messageFromThePresent)
 
 		require.Equal(t, 1, len(messagesHandler.history))
 	})
@@ -111,15 +111,15 @@ func TestFilterMessagesWithBadInstanceId(t *testing.T) {
 		state := mocks.NewMockState().WithHeightView(10, 0)
 		filter := rawmessagesfilter.NewConsensusMessageFilter(777, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
 		messagesHandler := NewTermMessagesHandlerMock()
-		filter.ConsumeCacheMessages(ctx, messagesHandler)
+		filter.ConsumeCacheMessages(messagesHandler)
 
 		messageWithGoodInstanceId := GeneratePreprepareMessage(777, 10, 20, "Sender MemberId")
 		messageWithBadInstanceId := GeneratePreprepareMessage(666, 10, 20, "Sender MemberId")
 
 		require.Equal(t, 0, len(messagesHandler.history))
 
-		filter.HandleConsensusRawMessage(ctx, messageWithGoodInstanceId)
-		filter.HandleConsensusRawMessage(ctx, messageWithBadInstanceId)
+		filter.HandleConsensusRawMessage(messageWithGoodInstanceId)
+		filter.HandleConsensusRawMessage(messageWithBadInstanceId)
 
 		require.Equal(t, 1, len(messagesHandler.history))
 	})
@@ -131,15 +131,15 @@ func TestCacheMessagesFromTheFuture(t *testing.T) {
 		state := mocks.NewMockState().WithHeightView(10, 0)
 		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
 		messagesHandler := NewTermMessagesHandlerMock()
-		filter.ConsumeCacheMessages(ctx, messagesHandler)
+		filter.ConsumeCacheMessages(messagesHandler)
 
 		messageFromTheFuture := GeneratePreprepareMessage(instanceId, 11, 20, "Sender MemberId")
 		messageFromThePresent := GeneratePreprepareMessage(instanceId, 10, 20, "Sender MemberId")
 
 		require.Equal(t, 0, len(messagesHandler.history))
 
-		filter.HandleConsensusRawMessage(ctx, messageFromTheFuture)
-		filter.HandleConsensusRawMessage(ctx, messageFromThePresent)
+		filter.HandleConsensusRawMessage(messageFromTheFuture)
+		filter.HandleConsensusRawMessage(messageFromThePresent)
 
 		require.Equal(t, 1, len(messagesHandler.history))
 	})
@@ -151,15 +151,15 @@ func TestFilterMessagesWithMyMemberId(t *testing.T) {
 		state := mocks.NewMockState().WithHeightView(10, 0)
 		filter := rawmessagesfilter.NewConsensusMessageFilter(instanceId, primitives.MemberId("My MemberId"), testLogger(state.State), state.State)
 		messagesHandler := NewTermMessagesHandlerMock()
-		filter.ConsumeCacheMessages(ctx, messagesHandler)
+		filter.ConsumeCacheMessages(messagesHandler)
 
 		badMessage := GeneratePreprepareMessage(instanceId, 11, 20, "My MemberId")
 		goodMessage := GeneratePreprepareMessage(instanceId, 10, 20, "Sender MemberId")
 
 		require.Equal(t, 0, len(messagesHandler.history))
 
-		filter.HandleConsensusRawMessage(ctx, badMessage)
-		filter.HandleConsensusRawMessage(ctx, goodMessage)
+		filter.HandleConsensusRawMessage(badMessage)
+		filter.HandleConsensusRawMessage(goodMessage)
 
 		require.Equal(t, 1, len(messagesHandler.history))
 	})

--- a/services/rawmessagesfilter/test/term_messages_handler_mock.go
+++ b/services/rawmessagesfilter/test/term_messages_handler_mock.go
@@ -7,7 +7,6 @@
 package test
 
 import (
-	"context"
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 )
 
@@ -19,7 +18,7 @@ func NewTermMessagesHandlerMock() *termMessagesHandlerMock {
 	return &termMessagesHandlerMock{}
 }
 
-func (t *termMessagesHandlerMock) HandleConsensusMessage(ctx context.Context, message interfaces.ConsensusMessage) error {
+func (t *termMessagesHandlerMock) HandleConsensusMessage(message interfaces.ConsensusMessage) error {
 	t.history = append(t.history, message)
 
 	return nil

--- a/services/termincommittee/test/term_in_committee_harness.go
+++ b/services/termincommittee/test/term_in_committee_harness.go
@@ -95,7 +95,7 @@ func (h *harness) triggerElection(ctx context.Context) {
 		panic("You are trying to trigger election with an election trigger that is not the ElectionTriggerMock")
 	}
 
-	electionTriggerMock.ManualTriggerSync(ctx)
+	electionTriggerMock.ManualTriggerSync()
 }
 
 func (h *harness) getMyNodeMemberId() primitives.MemberId {
@@ -147,19 +147,19 @@ func (h *harness) setMeAsTheLeader(ctx context.Context, blockHeight primitives.B
 func (h *harness) receiveAndHandlePreprepare(ctx context.Context, fromNode int, blockHeight primitives.BlockHeight, view primitives.View, block interfaces.Block) {
 	leader := h.net.Nodes[fromNode]
 	ppm := builders.APreprepareMessage(h.instanceId, leader.KeyManager, leader.MemberId, blockHeight, view, block)
-	h.termInCommittee.HandlePrePrepare(ctx, ppm)
+	h.termInCommittee.HandlePrePrepare(ppm)
 }
 
 func (h *harness) receiveAndHandlePrepare(ctx context.Context, fromNode int, blockHeight primitives.BlockHeight, view primitives.View, block interfaces.Block) {
 	sender := h.net.Nodes[fromNode]
 	pm := builders.APrepareMessage(h.instanceId, sender.KeyManager, sender.MemberId, blockHeight, view, block)
-	h.termInCommittee.HandlePrepare(ctx, pm)
+	h.termInCommittee.HandlePrepare(pm)
 }
 
 func (h *harness) receiveAndHandleViewChange(ctx context.Context, fromNodeIdx int, blockHeight primitives.BlockHeight, view primitives.View) {
 	sender := h.net.Nodes[fromNodeIdx]
 	vc := builders.AViewChangeMessage(h.instanceId, sender.KeyManager, sender.MemberId, blockHeight, view, nil)
-	h.termInCommittee.HandleViewChange(ctx, vc)
+	h.termInCommittee.HandleViewChange(vc)
 }
 
 func (h *harness) receiveAndHandleNewView(ctx context.Context, fromNodeIdx int, blockHeight primitives.BlockHeight, view primitives.View, block interfaces.Block) {
@@ -182,15 +182,15 @@ func (h *harness) receiveAndHandleNewView(ctx context.Context, fromNodeIdx int, 
 		OnBlockHeight(blockHeight).
 		OnView(view).
 		Build()
-	h.termInCommittee.HandleNewView(ctx, nvm)
+	h.termInCommittee.HandleNewView(nvm)
 }
 
 func (h *harness) handleViewChangeMessage(ctx context.Context, msg *interfaces.ViewChangeMessage) {
-	h.termInCommittee.HandleViewChange(ctx, msg)
+	h.termInCommittee.HandleViewChange(msg)
 }
 
 func (h *harness) handleNewViewMessage(ctx context.Context, nvm *interfaces.NewViewMessage) {
-	h.termInCommittee.HandleNewView(ctx, nvm)
+	h.termInCommittee.HandleNewView(nvm)
 }
 
 func (h *harness) createPreprepareMessage(fromNode int, blockHeight primitives.BlockHeight, view primitives.View, block interfaces.Block, blockHash primitives.BlockHash) *interfaces.PreprepareMessage {

--- a/services/termincommittee/test/term_in_committee_harness.go
+++ b/services/termincommittee/test/term_in_committee_harness.go
@@ -63,7 +63,7 @@ func NewHarness(ctx context.Context, t *testing.T, blocksPool ...interfaces.Bloc
 	log.Info("NewHarness calling NewTermInCommittee with H=%d", state.Height())
 
 	// TODO state.State is shadowing state.State and is generally meaninless
-	termInCommittee := termincommittee.NewTermInCommittee(ctx, log, termConfig, state.State, messageFactory, myNode.ElectionTrigger, committeeMembers, prevBlock, true, nil)
+	termInCommittee := termincommittee.NewTermInCommittee(log, termConfig, state.State, messageFactory, myNode.ElectionTrigger, committeeMembers, prevBlock, true, nil)
 
 	return &harness{
 		t:               t,

--- a/state/state.go
+++ b/state/state.go
@@ -11,8 +11,9 @@ import (
 // Mutable, goroutine-safe State object
 type State struct {
 	sync.RWMutex
-	height primitives.BlockHeight
-	view   primitives.View
+	height               primitives.BlockHeight
+	view                 primitives.View
+	WorkerContextManager *WorkerContextManager
 }
 
 func (s *State) CompareWithEffectiveHeightAndCancel(cancel context.CancelFunc, lastUpdated primitives.BlockHeight, height primitives.BlockHeight) (*HeightView, bool) {
@@ -118,8 +119,9 @@ func (s *State) HeightView() *HeightView {
 
 func NewState() *State {
 	return &State{
-		height: 0,
-		view:   0,
+		height:               0,
+		view:                 0,
+		WorkerContextManager: NewWorkerContextManager(),
 	}
 }
 
@@ -146,4 +148,8 @@ func (hv *HeightView) Height() primitives.BlockHeight {
 
 func (hv *HeightView) View() primitives.View {
 	return hv.view
+}
+
+func (hv *HeightView) OlderThan(otherHv *HeightView) bool {
+	return hv.Height() < otherHv.Height() || hv.Height() == otherHv.Height() && hv.View() < otherHv.View()
 }

--- a/state/state.go
+++ b/state/state.go
@@ -16,39 +16,6 @@ type State struct {
 	WorkerContextManager *WorkerContextManager
 }
 
-func (s *State) CompareWithEffectiveHeightAndCancel(cancel context.CancelFunc, lastUpdated primitives.BlockHeight, height primitives.BlockHeight) (*HeightView, bool) {
-	s.RLock()
-	defer s.RUnlock()
-
-	hv := NewHeightView(s.height, s.view)
-
-	effectiveHeight := s.height
-	if effectiveHeight < lastUpdated {
-		effectiveHeight = lastUpdated
-	}
-
-	if height < effectiveHeight {
-		return hv, false
-	}
-
-	cancel()
-	return hv, true
-}
-
-func (s *State) CancelContextIfHeightViewUnchanged(cancel context.CancelFunc, height primitives.BlockHeight, view primitives.View) (*HeightView, bool) {
-	s.RLock()
-	defer s.RUnlock()
-
-	hv := NewHeightView(s.height, s.view)
-
-	if s.height != height || s.view != view {
-		return hv, false
-	}
-
-	cancel()
-	return hv, true
-}
-
 func (s *State) SetHeightAndResetView(ctx context.Context, newHeight primitives.BlockHeight) (*HeightView, error) {
 	s.Lock()
 	defer s.Unlock()

--- a/state/state.go
+++ b/state/state.go
@@ -70,6 +70,10 @@ func (s *State) SetView(ctx context.Context, newView primitives.View) (*HeightVi
 	s.Lock()
 	defer s.Unlock()
 
+	if s.view == newView {
+		return NewHeightView(s.height, s.view), nil
+	}
+
 	if ctx.Err() == context.Canceled {
 		return NewHeightView(s.height, s.view), ctx.Err()
 	}
@@ -132,6 +136,9 @@ type HeightView struct {
 }
 
 func (hv *HeightView) String() string {
+	if hv == nil {
+		return "<nil HV>"
+	}
 	return fmt.Sprintf("H=%d,V=%d", hv.height, hv.view)
 }
 
@@ -151,5 +158,5 @@ func (hv *HeightView) View() primitives.View {
 }
 
 func (hv *HeightView) OlderThan(otherHv *HeightView) bool {
-	return hv.Height() < otherHv.Height() || hv.Height() == otherHv.Height() && hv.View() < otherHv.View()
+	return hv.Height() < otherHv.Height() || (hv.Height() == otherHv.Height() && hv.View() < otherHv.View())
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -9,19 +9,19 @@ import (
 
 func TestSetHeightResetsView(t *testing.T) {
 	state := NewState()
-	state.SetHeightView(context.Background(), 2, 3)
+	_, _ = state.SetHeightView(context.Background(), 2, 3)
 	require.Equal(t, primitives.BlockHeight(2), state.Height(), "returned incorrect height")
 	require.Equal(t, primitives.View(3), state.View(), "returned incorrect view")
-	state.SetHeightAndResetView(4)
+	_, _ = state.SetHeightAndResetView(4)
 	require.Equal(t, primitives.BlockHeight(4), state.Height(), "returned incorrect height")
 	require.Equal(t, primitives.View(0), state.View(), "returned incorrect view")
 }
 
 func TestReturnCorrectHeightViewInstance(t *testing.T) {
 	state := NewState()
-	state.SetHeightView(context.Background(), 2, 3)
+	_, _ = state.SetHeightView(context.Background(), 2, 3)
 	hv := state.HeightView()
-	state.SetHeightView(context.Background(), 4, 5)
+	_, _ = state.SetHeightView(context.Background(), 4, 5)
 	require.Equal(t, primitives.BlockHeight(2), hv.Height(), "returned incorrect height")
 	require.Equal(t, primitives.View(3), hv.View(), "returned incorrect view")
 }

--- a/state/state_test.go
+++ b/state/state_test.go
@@ -12,7 +12,7 @@ func TestSetHeightResetsView(t *testing.T) {
 	state.SetHeightView(context.Background(), 2, 3)
 	require.Equal(t, primitives.BlockHeight(2), state.Height(), "returned incorrect height")
 	require.Equal(t, primitives.View(3), state.View(), "returned incorrect view")
-	state.SetHeightAndResetView(context.Background(),4)
+	state.SetHeightAndResetView(4)
 	require.Equal(t, primitives.BlockHeight(4), state.Height(), "returned incorrect height")
 	require.Equal(t, primitives.View(0), state.View(), "returned incorrect view")
 }

--- a/state/view_contexts.go
+++ b/state/view_contexts.go
@@ -32,7 +32,7 @@ func NewViewContexts() *ViewContexts {
 	}
 }
 
-func (w *ViewContexts) ActiveFor(hv *HeightView) (context.Context, error) {
+func (w *ViewContexts) For(hv *HeightView) (context.Context, error) {
 	w.mutex.Lock()
 	defer w.mutex.Unlock()
 

--- a/state/worker_context_manager.go
+++ b/state/worker_context_manager.go
@@ -1,0 +1,76 @@
+package state
+
+import (
+	"context"
+	"sync"
+)
+
+type contextWithCancel struct {
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+type WorkerContextManager struct {
+	hvToContext           map[HeightView]*contextWithCancel
+	newestHvCanceledOlder *HeightView
+	parentCtxWithCancel   *contextWithCancel
+	mutex                 *sync.Mutex
+}
+
+func NewWorkerContextManager() *WorkerContextManager {
+	return &WorkerContextManager{
+		hvToContext:           make(map[HeightView]*contextWithCancel),
+		newestHvCanceledOlder: nil,
+		parentCtxWithCancel:   nil,
+		mutex:                 &sync.Mutex{},
+	}
+}
+
+func (w *WorkerContextManager) Init(parent context.Context) {
+	ctx, cancel := context.WithCancel(parent)
+	w.parentCtxWithCancel = &contextWithCancel{
+		ctx:    ctx,
+		cancel: cancel,
+	}
+}
+
+func (w *WorkerContextManager) GetOrCreateContextFor(hv *HeightView) (context.Context, bool) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	if w.newestHvCanceledOlder != nil && hv.OlderThan(w.newestHvCanceledOlder) {
+		return nil, false
+	}
+
+	cc, ok := w.hvToContext[*hv]
+	if !ok {
+		ctx, cancel := context.WithCancel(w.parentCtxWithCancel.ctx)
+		cc = &contextWithCancel{
+			ctx:    ctx,
+			cancel: cancel,
+		}
+		w.hvToContext[*hv] = cc
+	}
+
+	return cc.ctx, true
+}
+
+func (w *WorkerContextManager) CancelContextsOlderThan(hv *HeightView) {
+	w.mutex.Lock()
+	defer w.mutex.Unlock()
+
+	for chv, cc := range w.hvToContext {
+		if chv.OlderThan(hv) {
+			cc.cancel()
+			delete(w.hvToContext, chv)
+		}
+	}
+
+	if w.newestHvCanceledOlder == nil || w.newestHvCanceledOlder.OlderThan(hv) {
+		w.newestHvCanceledOlder = hv
+	}
+}
+
+func (w *WorkerContextManager) CancelAll() {
+	w.parentCtxWithCancel.cancel()
+}

--- a/test/leanhelix/driver.go
+++ b/test/leanhelix/driver.go
@@ -1,0 +1,79 @@
+package leanhelix
+
+import (
+	"context"
+	"github.com/orbs-network/lean-helix-go"
+	"github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/lean-helix-go/services/messagesfactory"
+	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
+	"github.com/orbs-network/lean-helix-go/state"
+	"github.com/orbs-network/lean-helix-go/test/mocks"
+	"math/rand"
+)
+
+type driver struct {
+	instanceId          primitives.InstanceId
+	communication       *mocks.CommunicationMock
+	config              *interfaces.Config
+	leadersByView       []primitives.MemberId
+	mainLoop            *leanhelix.MainLoop
+	electionTriggerMock *mocks.ElectionTriggerMock
+}
+
+func newDriver(logger interfaces.Logger, becomeLeaderInView byte, totalMembers byte) *driver {
+	if becomeLeaderInView >= totalMembers {
+		panic("current node must be in committee")
+	}
+
+	instanceId := primitives.InstanceId(0)
+	discoveryMock := mocks.NewDiscovery()
+
+	leadersByView := make([]primitives.MemberId, totalMembers)
+	communications := make([]*mocks.CommunicationMock, totalMembers)
+
+	for i := byte(0); i < totalMembers; i++ {
+		leadersByView[i] = primitives.MemberId{i}
+		communications[i] = mocks.NewCommunication(leadersByView[i], discoveryMock, logger)
+		// set leadership rotation order through views
+		discoveryMock.RegisterCommunication(leadersByView[i], communications[i])
+	}
+
+	currentMemberId := leadersByView[becomeLeaderInView]
+	currentMemberCommunication := communications[becomeLeaderInView]
+
+	membership := mocks.NewFakeMembership(currentMemberId, discoveryMock, false)
+
+	keyManager := mocks.NewMockKeyManager(currentMemberId)
+	keyManager.DisableConsensusMessageVerification()
+
+	electionTriggerMock := mocks.NewMockElectionTrigger()
+	config := mocks.NewMockConfig(
+		logger,
+		instanceId,
+		membership,
+		mocks.NewMockBlockUtils(currentMemberId, mocks.NewBlocksPool(nil), logger),
+		keyManager,
+		electionTriggerMock,
+		currentMemberCommunication,
+	)
+
+	mainLoop := leanhelix.NewLeanHelix(config, nil, nil)
+
+	return &driver{
+		instanceId:          instanceId,
+		communication:       currentMemberCommunication,
+		config:              config,
+		leadersByView:       leadersByView,
+		mainLoop:            mainLoop,
+		electionTriggerMock: electionTriggerMock,
+	}
+}
+
+func (d *driver) handleViewChangeMessage(ctx context.Context, hv *state.HeightView, fromLeaderAtView byte) {
+	randomSeed := rand.Uint64()
+	messageFactory := messagesfactory.NewMessageFactory(d.instanceId, d.config.KeyManager, d.leadersByView[fromLeaderAtView], randomSeed)
+
+	message := messageFactory.CreateViewChangeMessage(hv.Height(), hv.View(), nil)
+
+	d.mainLoop.HandleConsensusMessage(ctx, message.ToConsensusRawMessage())
+}

--- a/test/leanhelix/driver.go
+++ b/test/leanhelix/driver.go
@@ -6,9 +6,15 @@ import (
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 	"github.com/orbs-network/lean-helix-go/services/messagesfactory"
 	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
+	"github.com/orbs-network/lean-helix-go/spec/types/go/protocol"
 	"github.com/orbs-network/lean-helix-go/state"
+	"github.com/orbs-network/lean-helix-go/test"
+	"github.com/orbs-network/lean-helix-go/test/builders"
 	"github.com/orbs-network/lean-helix-go/test/mocks"
+	"github.com/stretchr/testify/require"
 	"math/rand"
+	"testing"
+	"time"
 )
 
 type driver struct {
@@ -18,9 +24,10 @@ type driver struct {
 	leadersByView       []primitives.MemberId
 	mainLoop            *leanhelix.MainLoop
 	electionTriggerMock *mocks.ElectionTriggerMock
+	discovery           *mocks.Discovery
 }
 
-func newDriver(logger interfaces.Logger, becomeLeaderInView byte, totalMembers byte) *driver {
+func newDriver(logger interfaces.Logger, becomeLeaderInView byte, totalMembers byte, onCommitCallback interfaces.OnCommitCallback) *driver {
 	if becomeLeaderInView >= totalMembers {
 		panic("current node must be in committee")
 	}
@@ -57,7 +64,7 @@ func newDriver(logger interfaces.Logger, becomeLeaderInView byte, totalMembers b
 		currentMemberCommunication,
 	)
 
-	mainLoop := leanhelix.NewLeanHelix(config, nil, nil)
+	mainLoop := leanhelix.NewLeanHelix(config, onCommitCallback, nil)
 
 	return &driver{
 		instanceId:          instanceId,
@@ -66,6 +73,7 @@ func newDriver(logger interfaces.Logger, becomeLeaderInView byte, totalMembers b
 		leadersByView:       leadersByView,
 		mainLoop:            mainLoop,
 		electionTriggerMock: electionTriggerMock,
+		discovery:           discoveryMock,
 	}
 }
 
@@ -76,4 +84,30 @@ func (d *driver) handleViewChangeMessage(ctx context.Context, hv *state.HeightVi
 	message := messageFactory.CreateViewChangeMessage(hv.Height(), hv.View(), nil)
 
 	d.mainLoop.HandleConsensusMessage(ctx, message.ToConsensusRawMessage())
+}
+
+func (d *driver) waitForSentPreprepareMessage(t *testing.T, i int) *interfaces.PreprepareMessage {
+	require.True(t, test.Eventually(time.Second, func() bool {
+		return len(d.communication.GetSentMessages(protocol.LEAN_HELIX_PREPREPARE)) >= i
+	}), "expected a preprepare message to be sent within timeout")
+	message := interfaces.ToConsensusMessage(d.communication.GetSentMessages(protocol.LEAN_HELIX_PREPREPARE)[i-1]).(*interfaces.PreprepareMessage)
+	return message
+}
+
+func (d *driver) waitForSentCommitMessage(t *testing.T, i int) *interfaces.CommitMessage {
+	require.True(t, test.Eventually(time.Second, func() bool {
+		return len(d.communication.GetSentMessages(protocol.LEAN_HELIX_COMMIT)) >= i
+	}), "expected a commit message to be sent within timeout")
+	message := interfaces.ToConsensusMessage(d.communication.GetSentMessages(protocol.LEAN_HELIX_COMMIT)[i-1]).(*interfaces.CommitMessage)
+	return message
+}
+
+func (d *driver) receivePrepareMessageForBlock(ctx context.Context, from primitives.MemberId, height primitives.BlockHeight, view primitives.View, block interfaces.Block) {
+	message := builders.APrepareMessage(d.instanceId, mocks.NewMockKeyManager(from), from, height, view, block)
+	d.mainLoop.HandleConsensusMessage(ctx, message.ToConsensusRawMessage())
+}
+
+func (d *driver) receiveCommitMessageForBlock(ctx context.Context, from primitives.MemberId, height primitives.BlockHeight, view primitives.View, block interfaces.Block, randomSeed uint64) {
+	message := builders.ACommitMessage(d.instanceId, mocks.NewMockKeyManager(from), from, primitives.BlockHeight(1), primitives.View(0), block, randomSeed)
+	d.mainLoop.HandleConsensusMessage(ctx, message.ToConsensusRawMessage()) // commit from 1
 }

--- a/test/leanhelix/mainloop_component_test.go
+++ b/test/leanhelix/mainloop_component_test.go
@@ -173,7 +173,7 @@ func TestViewChangeRaceWithElectionLeader(t *testing.T) {
 		require.NoError(t, err)
 
 		require.True(t, test.Eventually(time.Second, func() bool {
-			return d.mainLoop.State().Height() == 1
+			return d.electionTriggerMock.GetRegisteredHeight() == 1
 		}))
 
 		// receive VIEW_CHANGE messages form other committee members

--- a/test/leanhelix/mainloop_component_test.go
+++ b/test/leanhelix/mainloop_component_test.go
@@ -169,6 +169,10 @@ func TestViewChangeRaceWithElectionLeader(t *testing.T) {
 		err := d.mainLoop.UpdateState(ctx, interfaces.GenesisBlock, nil)
 		require.NoError(t, err)
 
+		require.True(t, test.Eventually(time.Second, func() bool {
+			return d.mainLoop.State().Height() == 1
+		}))
+
 		// receive VIEW_CHANGE messages form other committee members
 		nextView := state.NewHeightView(1, 1)
 		d.handleViewChangeMessage(ctx, nextView, 0)

--- a/test/mocks/config_mock.go
+++ b/test/mocks/config_mock.go
@@ -1,10 +1,31 @@
 package mocks
 
-import "github.com/orbs-network/lean-helix-go/services/interfaces"
+import (
+	"github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
+)
 
-func NewMockConfig() *interfaces.Config {
+func NewMockConfigSimple() *interfaces.Config {
+	membership := NewFakeMembership([]byte{30, 30, 30}, nil, false)
+	return NewMockConfig(
+		nil,
+		0,
+		membership,
+		nil,
+		nil,
+		nil,
+		nil,
+	)
+}
+
+func NewMockConfig(logger interfaces.Logger, instanceId primitives.InstanceId, membership interfaces.Membership, blockUtils interfaces.BlockUtils, keyManager interfaces.KeyManager, electionSched interfaces.ElectionScheduler, communication interfaces.Communication) *interfaces.Config {
 	return &interfaces.Config{
-		Logger:     nil,
-		Membership: NewFakeMembership([]byte{30, 30, 30}, nil, false),
+		Logger:                  logger,
+		Membership:              membership,
+		BlockUtils:              blockUtils,
+		KeyManager:              keyManager,
+		OverrideElectionTrigger: electionSched,
+		InstanceId:              instanceId,
+		Communication:           communication,
 	}
 }

--- a/test/mocks/election_trigger_mock.go
+++ b/test/mocks/election_trigger_mock.go
@@ -17,7 +17,7 @@ import (
 type ElectionTriggerMock struct {
 	blockHeight     primitives.BlockHeight
 	view            primitives.View
-	electionHandler func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback)
+	electionHandler func(blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback)
 	electionChannel chan *interfaces.ElectionTrigger
 }
 
@@ -35,7 +35,7 @@ func NewMockElectionTrigger() *ElectionTriggerMock {
 	}
 }
 
-func (et *ElectionTriggerMock) RegisterOnElection(blockHeight primitives.BlockHeight, view primitives.View, cb func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback)) {
+func (et *ElectionTriggerMock) RegisterOnElection(blockHeight primitives.BlockHeight, view primitives.View, cb func(blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback)) {
 	et.view = view
 	et.blockHeight = blockHeight
 	et.electionHandler = cb
@@ -61,14 +61,14 @@ func (et *ElectionTriggerMock) ManualTrigger(ctx context.Context, hv *state.Heig
 	return done
 }
 
-func (et *ElectionTriggerMock) electionTriggerHandler(ctx context.Context) {
+func (et *ElectionTriggerMock) electionTriggerHandler() {
 	if et.electionHandler != nil {
-		et.electionHandler(ctx, et.blockHeight, et.view, nil)
+		et.electionHandler(et.blockHeight, et.view, nil)
 	}
 }
 
-func (et *ElectionTriggerMock) ManualTriggerSync(ctx context.Context) {
+func (et *ElectionTriggerMock) ManualTriggerSync() {
 	if et.electionHandler != nil {
-		et.electionHandler(ctx, et.blockHeight, et.view, nil)
+		et.electionHandler(et.blockHeight, et.view, nil)
 	}
 }

--- a/test/mocks/election_trigger_mock.go
+++ b/test/mocks/election_trigger_mock.go
@@ -11,6 +11,7 @@ import (
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
 	"github.com/orbs-network/lean-helix-go/state"
+	"sync/atomic"
 	"time"
 )
 
@@ -36,8 +37,8 @@ func NewMockElectionTrigger() *ElectionTriggerMock {
 }
 
 func (et *ElectionTriggerMock) RegisterOnElection(blockHeight primitives.BlockHeight, view primitives.View, cb func(blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback)) {
+	atomic.StoreUint64((*uint64)(&et.blockHeight), uint64(blockHeight))
 	et.view = view
-	et.blockHeight = blockHeight
 	et.electionHandler = cb
 }
 
@@ -63,12 +64,16 @@ func (et *ElectionTriggerMock) ManualTrigger(ctx context.Context, hv *state.Heig
 
 func (et *ElectionTriggerMock) electionTriggerHandler() {
 	if et.electionHandler != nil {
-		et.electionHandler(et.blockHeight, et.view, nil)
+		et.electionHandler(et.GetRegisteredHeight(), et.view, nil)
 	}
 }
 
 func (et *ElectionTriggerMock) ManualTriggerSync() {
 	if et.electionHandler != nil {
-		et.electionHandler(et.blockHeight, et.view, nil)
+		et.electionHandler(et.GetRegisteredHeight(), et.view, nil)
 	}
+}
+
+func (et *ElectionTriggerMock) GetRegisteredHeight() primitives.BlockHeight {
+	return 	primitives.BlockHeight(atomic.LoadUint64((*uint64)(&et.blockHeight)))
 }

--- a/test/mocks/term_messages_handler_mock.go
+++ b/test/mocks/term_messages_handler_mock.go
@@ -7,7 +7,6 @@
 package mocks
 
 import (
-	"context"
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 )
 
@@ -23,22 +22,22 @@ func NewTermMessagesHandlerMock() *TermMessagesHandlerMock {
 	return &TermMessagesHandlerMock{}
 }
 
-func (tmh *TermMessagesHandlerMock) HandlePrePrepare(ctx context.Context, ppm *interfaces.PreprepareMessage) {
+func (tmh *TermMessagesHandlerMock) HandlePrePrepare(ppm *interfaces.PreprepareMessage) {
 	tmh.HistoryPP = append(tmh.HistoryPP, ppm)
 }
 
-func (tmh *TermMessagesHandlerMock) HandlePrepare(ctx context.Context, pm *interfaces.PrepareMessage) {
+func (tmh *TermMessagesHandlerMock) HandlePrepare(pm *interfaces.PrepareMessage) {
 	tmh.HistoryP = append(tmh.HistoryP, pm)
 }
 
-func (tmh *TermMessagesHandlerMock) HandleCommit(ctx context.Context, cm *interfaces.CommitMessage) {
+func (tmh *TermMessagesHandlerMock) HandleCommit(cm *interfaces.CommitMessage) {
 	tmh.HistoryC = append(tmh.HistoryC, cm)
 }
 
-func (tmh *TermMessagesHandlerMock) HandleNewView(ctx context.Context, nvm *interfaces.NewViewMessage) {
+func (tmh *TermMessagesHandlerMock) HandleNewView(nvm *interfaces.NewViewMessage) {
 	tmh.HistoryNV = append(tmh.HistoryNV, nvm)
 }
 
-func (tmh *TermMessagesHandlerMock) HandleViewChange(ctx context.Context, vcm *interfaces.ViewChangeMessage) {
+func (tmh *TermMessagesHandlerMock) HandleViewChange(vcm *interfaces.ViewChangeMessage) {
 	tmh.HistoryVC = append(tmh.HistoryVC, vcm)
 }

--- a/test/mocks/tests/election_trigger_mock_test.go
+++ b/test/mocks/tests/election_trigger_mock_test.go
@@ -29,7 +29,7 @@ func TestCallingCallback(t *testing.T) {
 		var actualHeight primitives.BlockHeight = 666
 		var expectedView primitives.View = 10
 		var expectedHeight primitives.BlockHeight = 20
-		cb := func(ctx context.Context, blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback) {
+		cb := func(blockHeight primitives.BlockHeight, view primitives.View, onElectionCB interfaces.OnElectionCallback) {
 			actualHeight = blockHeight
 			actualView = view
 		}
@@ -37,7 +37,7 @@ func TestCallingCallback(t *testing.T) {
 
 		go et.ManualTrigger(ctx, state.NewHeightView(actualHeight, actualView))
 		trigger := <-et.ElectionChannel()
-		trigger.MoveToNextLeader(ctx)
+		trigger.MoveToNextLeader()
 
 		require.Equal(t, expectedView, actualView)
 		require.Equal(t, expectedHeight, actualHeight)
@@ -50,6 +50,6 @@ func TestIgnoreEmptyCallback(t *testing.T) {
 
 		go et.ManualTrigger(ctx, state.NewHeightView(0, 1))
 		trigger := <-et.ElectionChannel()
-		trigger.MoveToNextLeader(ctx)
+		trigger.MoveToNextLeader()
 	})
 }

--- a/test/network/node.go
+++ b/test/network/node.go
@@ -78,7 +78,7 @@ func (node *Node) TriggerElectionOnNode(ctx context.Context) <-chan struct{} {
 	return electionTriggerMock.ManualTrigger(ctx, hv)
 }
 
-func (node *Node) onCommittedBlock(ctx context.Context, block interfaces.Block, blockProof []byte) {
+func (node *Node) onCommittedBlock(ctx context.Context, block interfaces.Block, blockProof []byte) error {
 	node.blockChain.AppendBlockToChain(block, blockProof)
 	node.log.Debug("ID=%s onCommittedBlock: appended to blockchain: %s", node.MemberId, block)
 
@@ -90,12 +90,14 @@ func (node *Node) onCommittedBlock(ctx context.Context, block interfaces.Block, 
 
 		select {
 		case <-ctx.Done():
-			return
+			return nil
 
 		case node.CommittedBlockChannel <- nodeState:
-			return
+			return nil
 		}
 	}
+
+	return nil
 }
 
 func (node *Node) Blockchain() *mocks.InMemoryBlockchain {

--- a/test/network/test_network.go
+++ b/test/network/test_network.go
@@ -107,6 +107,9 @@ func (net *TestNetwork) WaitUntilSubsetOfNodesEventuallyReachASpecificHeight(ctx
 			for node.GetCurrentHeight() < height {
 				iterationTimeout, _ := context.WithTimeout(ctx, 20*time.Millisecond)
 				<-iterationTimeout.Done() // sleep or get cancelled
+				if ctx.Err() != nil {
+					return
+				}
 			}
 
 			select {

--- a/test/network/test_network.go
+++ b/test/network/test_network.go
@@ -225,10 +225,14 @@ func (net *TestNetwork) AllNodesValidatedNoMoreThanOnceBeforeCommit(ctx context.
 	return true
 }
 
-func (net *TestNetwork) TriggerElectionsOnAllNodes(ctx context.Context) {
-	for _, n := range net.Nodes {
+func (net *TestNetwork) TriggerElectionsOnNodes(ctx context.Context, nodes ...*Node) {
+	for _, n := range nodes {
 		<-n.TriggerElectionOnNode(ctx)
 	}
+}
+
+func (net *TestNetwork) TriggerElectionsOnAllNodes(ctx context.Context) {
+	net.TriggerElectionsOnNodes(ctx, net.Nodes...)
 }
 
 func (net *TestNetwork) WaitForShutdown(ctx context.Context) {

--- a/workerloop.go
+++ b/workerloop.go
@@ -70,9 +70,9 @@ func NewWorkerLoop(
 	logger.Debug("LHFLOW NewWorkerLoop()")
 	filter := rawmessagesfilter.NewConsensusMessageFilter(config.InstanceId, config.Membership.MyMemberId(), logger, state)
 	return &WorkerLoop{
-		MessagesChannel:             make(chan *MessageWithContext, 1000),
-		workerUpdateStateChannel:    make(chan *workerUpdateStateMessage),
-		electionChannel:             make(chan *workerElectionsTriggerMessage),
+		MessagesChannel:             make(chan *MessageWithContext, 1000), // TODO config.MsgChanBufLen
+		workerUpdateStateChannel:    make(chan *workerUpdateStateMessage, 1), // must be at least 1 // TODO config.UpdateStateChanBufLen
+		electionChannel:             make(chan *workerElectionsTriggerMessage, 1), // must be at least 1 // TODO config.ElectionChanBufLen
 		electionTrigger:             electionTrigger,
 		state:                       state,
 		config:                      config,

--- a/workerloop.go
+++ b/workerloop.go
@@ -226,9 +226,7 @@ func (lh *WorkerLoop) ValidateBlockConsensus(ctx context.Context, block interfac
 func (lh *WorkerLoop) onCommit(ctx context.Context, block interfaces.Block, blockProofBytes []byte) error {
 	height := block.Height()
 	lh.logger.Debug("LHFLOW onCommitCallback START from leanhelix.onCommit() ID=%s H=%d", lh.config.Membership.MyMemberId(), height)
-
-	// TODO Gad: Should this check for errors and not call onNewConsensusRound
-
+	
 	err := lh.onCommitCallback(ctx, block, blockProofBytes)
 	if err != nil {
 		lh.logger.Debug("LHFLOW onCommitCallback FAILED - %s", err.Error())

--- a/workerloop.go
+++ b/workerloop.go
@@ -223,16 +223,22 @@ func (lh *WorkerLoop) ValidateBlockConsensus(ctx context.Context, block interfac
 	return nil
 }
 
-func (lh *WorkerLoop) onCommit(ctx context.Context, block interfaces.Block, blockProofBytes []byte) {
+func (lh *WorkerLoop) onCommit(ctx context.Context, block interfaces.Block, blockProofBytes []byte) error {
 	height := block.Height()
 	lh.logger.Debug("LHFLOW onCommitCallback START from leanhelix.onCommit() ID=%s H=%d", lh.config.Membership.MyMemberId(), height)
 
 	// TODO Gad: Should this check for errors and not call onNewConsensusRound
 
-	lh.onCommitCallback(ctx, block, blockProofBytes)
+	err := lh.onCommitCallback(ctx, block, blockProofBytes)
+	if err != nil {
+		lh.logger.Debug("LHFLOW onCommitCallback FAILED - %s", err.Error())
+		return err
+	}
 	lh.logger.Debug("LHFLOW onCommitCallback RETURNED from leanhelix.onCommit()")
 	lh.logger.Debug("Calling onNewConsensusRound() from leanhelix.onCommit()")
 	lh.onNewConsensusRound(block, blockProofBytes, true)
+
+	return nil
 }
 
 func (lh *WorkerLoop) onNewConsensusRound(prevBlock interfaces.Block, prevBlockProofBytes []byte, canBeFirstLeader bool) {

--- a/workerloop.go
+++ b/workerloop.go
@@ -224,7 +224,7 @@ func (lh *WorkerLoop) onCommit(ctx context.Context, block interfaces.Block, bloc
 
 func (lh *WorkerLoop) onNewConsensusRound(prevBlock interfaces.Block, prevBlockProofBytes []byte, canBeFirstLeader bool) {
 	hv := state.NewHeightView(blockheight.GetBlockHeight(prevBlock)+1, 0)
-	ctx, err := lh.state.ViewContexts.ActiveFor(hv)
+	ctx, err := lh.state.Contexts.For(hv)
 	if err != nil {
 		lh.logger.Info("onNewConsensusRound() error: %e", err)
 		return
@@ -256,5 +256,5 @@ func (lh *WorkerLoop) cleanupCurrentTerm() {
 }
 
 func (lh *WorkerLoop) interrupt() {
-	lh.state.ViewContexts.Shutdown()
+	lh.state.Contexts.Shutdown()
 }


### PR DESCRIPTION
resolves #74 

Solution involves allocating a context for each target height/view, and accessing the appropriate worker context whenever the worker loop requires a context to make calls into Orbs.

This allows better control over cancellation of the appropriate heights and views.

The more risk for a situation where the worker loop blocks on a long running call using one context and the main loop tries to cancel another context leading to a possible deadlock which may block the main loop until the worker loop recovers without a possibility to cancel the contest. the previous implementation was more aggressive in cancelling contexts and less vulnerable to these edge cases. As a result, the main loop now can never be blocked: All it's interactions with worker loop channels are non blocking. 