### PR TITLE
Allow a prepared node to commit in older view

### DIFF
--- a/mainloop.go
+++ b/mainloop.go
@@ -118,12 +118,6 @@ func (m *MainLoop) run(ctx context.Context) {
 
 			m.logger.Debug("LHFLOW LHMSG MAINLOOP RECEIVED %v from %v for H=%d V=%d", parsedMessage.MessageType(), parsedMessage.SenderMemberId(), parsedMessage.BlockHeight(), parsedMessage.View())
 
-			_, err := m.state.Contexts.For(state.NewHeightView(parsedMessage.BlockHeight(), parsedMessage.View()))
-			if err != nil {
-				m.logger.Debug("LHFLOW LHMSG MAINLOOP - IGNORING RECEIVED MESSAGE %v FROM %v WITH %e", parsedMessage.MessageType(), parsedMessage.SenderMemberId(), err)
-				continue
-			}
-
 			select {
 			default: // never block the main loop
 			case <-ctx.Done(): // here for uniformity, made redundant by default:

--- a/services/termincommittee/term_in_committee.go
+++ b/services/termincommittee/term_in_committee.go
@@ -22,6 +22,7 @@ import (
 	"github.com/orbs-network/lean-helix-go/spec/types/go/protocol"
 	"github.com/orbs-network/lean-helix-go/state"
 	"github.com/pkg/errors"
+	"math"
 	"runtime"
 	"sort"
 	"strings"
@@ -30,7 +31,8 @@ import (
 // The algorithm cannot function with less committee members
 // because it cannot calculate the f number (where committee members are 3f+1)
 // The only reason to set this manually in config below this limit is for internal tests
-const LEAN_HELIX_HARD_MINIMUM_COMMITTEE_MEMBERS = 4
+const LeanHelixHardMinimumCommitteeMembers = 4
+const MaxView = math.MaxUint64
 
 type TermInCommittee struct {
 	keyManager                      interfaces.KeyManager
@@ -134,8 +136,8 @@ func ToCommitteeMembersStr(members []primitives.MemberId) string {
 }
 
 func panicOnLessThanMinimumCommitteeMembers(committeeMembers []primitives.MemberId) {
-	if len(committeeMembers) < LEAN_HELIX_HARD_MINIMUM_COMMITTEE_MEMBERS {
-		panic(fmt.Sprintf("LH Received only %d committee members, but the hard minimum is %d", len(committeeMembers), LEAN_HELIX_HARD_MINIMUM_COMMITTEE_MEMBERS))
+	if len(committeeMembers) < LeanHelixHardMinimumCommitteeMembers {
+		panic(fmt.Sprintf("LH Received only %d committee members, but the hard minimum is %d", len(committeeMembers), LeanHelixHardMinimumCommitteeMembers))
 	}
 }
 
@@ -539,7 +541,7 @@ func (tic *TermInCommittee) checkCommitted(blockHeight primitives.BlockHeight, v
 		return
 	}
 
-	ctx, err := tic.State.Contexts.For(state.NewHeightView(blockHeight, view))
+	ctx, err := tic.State.Contexts.For(state.NewHeightView(blockHeight, MaxView)) // umbrella context for current term
 	if err != nil {
 		tic.logger.Debug("LHMSG RECEIVED COMMIT IGNORE - %e", err)
 		return

--- a/services/termincommittee/test/term_in_committee_harness.go
+++ b/services/termincommittee/test/term_in_committee_harness.go
@@ -95,7 +95,7 @@ func (h *harness) triggerElection(ctx context.Context) {
 		panic("You are trying to trigger election with an election trigger that is not the ElectionTriggerMock")
 	}
 
-	electionTriggerMock.ManualTriggerSync()
+	electionTriggerMock.InvokeElectionHandler()
 }
 
 func (h *harness) getMyNodeMemberId() primitives.MemberId {

--- a/test/mocks/election_trigger_mock.go
+++ b/test/mocks/election_trigger_mock.go
@@ -53,7 +53,7 @@ func (et *ElectionTriggerMock) ManualTrigger(ctx context.Context, hv *state.Heig
 		case <-ctx.Done():
 			close(done)
 		case et.electionChannel <- &interfaces.ElectionTrigger{
-			MoveToNextLeader: et.electionTriggerHandler,
+			MoveToNextLeader: et.InvokeElectionHandler,
 			Hv:               state.NewHeightView(hv.Height(), hv.View()),
 		}:
 			close(done)
@@ -62,18 +62,12 @@ func (et *ElectionTriggerMock) ManualTrigger(ctx context.Context, hv *state.Heig
 	return done
 }
 
-func (et *ElectionTriggerMock) electionTriggerHandler() {
-	if et.electionHandler != nil {
-		et.electionHandler(et.GetRegisteredHeight(), et.view, nil)
-	}
-}
-
-func (et *ElectionTriggerMock) ManualTriggerSync() {
+func (et *ElectionTriggerMock) InvokeElectionHandler() {
 	if et.electionHandler != nil {
 		et.electionHandler(et.GetRegisteredHeight(), et.view, nil)
 	}
 }
 
 func (et *ElectionTriggerMock) GetRegisteredHeight() primitives.BlockHeight {
-	return 	primitives.BlockHeight(atomic.LoadUint64((*uint64)(&et.blockHeight)))
+	return primitives.BlockHeight(atomic.LoadUint64((*uint64)(&et.blockHeight)))
 }


### PR DESCRIPTION
allow a prepared node to commit view context cancelled by election trigger.

- Don't check context validity in mainloop for incoming consensus messages
- Use a context that will never expire in the current term when calling `onCommit()` callback