### PR TITLE
Fix race between RequestOrderedCommittee and election trigger

### DIFF
--- a/services/leanhelixterm/leanhelix_term.go
+++ b/services/leanhelixterm/leanhelix_term.go
@@ -57,7 +57,7 @@ func NewLeanHelixTerm(ctx context.Context, log logger.LHLogger, config *interfac
 
 func requestOrderedCommittee(s *state.State, blockHeight primitives.BlockHeight, randomSeed uint64, config *interfaces.Config) ([]primitives.MemberId, error) {
 	const maxView = primitives.View(math.MaxUint64)
-	ctx, err := s.Contexts.For(state.NewHeightView(blockHeight, maxView)) // getting the committee is relevant to all views under this term
+	ctx, err := s.Contexts.For(state.NewHeightView(blockHeight, maxView)) // term-level context
 	if err != nil {
 		return nil, err
 	}

--- a/services/leanhelixterm/leanhelix_term.go
+++ b/services/leanhelixterm/leanhelix_term.go
@@ -19,6 +19,7 @@ import (
 	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
 	"github.com/orbs-network/lean-helix-go/spec/types/go/protocol"
 	"github.com/orbs-network/lean-helix-go/state"
+	"math"
 )
 
 type LeanHelixTerm struct {
@@ -55,7 +56,8 @@ func NewLeanHelixTerm(ctx context.Context, log logger.LHLogger, config *interfac
 }
 
 func requestOrderedCommittee(s *state.State, blockHeight primitives.BlockHeight, randomSeed uint64, config *interfaces.Config) ([]primitives.MemberId, error) {
-	ctx, err := s.Contexts.For(state.NewHeightView(blockHeight, 0))
+	const maxView = primitives.View(math.MaxUint64)
+	ctx, err := s.Contexts.For(state.NewHeightView(blockHeight, maxView)) // getting the committee is relevant to all views under this term
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
If an election trigger pops in the middle of `RequestOrderedCommittee`, it will fail and the node will be left out of the term. This is highly unlikely to happen in production as the base view timeout is high, but it happened locally for me in one of the tests.

This fixes it by allocating a term-level context for `RequestOrderedCommittee` which will only get cancelled when entering the next term.

(this is just the fix without a test, will add test after a review by @gadcl and @ronnno ) 