### PR TITLE
added a semantic logger for consensus state changes

### DIFF
--- a/mainloop.go
+++ b/mainloop.go
@@ -262,7 +262,6 @@ func (m *MainLoop) UpdateState(ctx context.Context, prevBlock interfaces.Block, 
 }
 
 func (m *MainLoop) HandleConsensusMessage(ctx context.Context, message *interfaces.ConsensusRawMessage) {
-
 	select {
 	case <-ctx.Done():
 		m.logger.Debug("HandleConsensusRawMessage() ID=%s CONTEXT CANCELED", termincommittee.Str(m.config.Membership.MyMemberId()))

--- a/services/interfaces/external_interfaces.go
+++ b/services/interfaces/external_interfaces.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
 	"github.com/orbs-network/lean-helix-go/spec/types/go/protocol"
 	"github.com/orbs-network/lean-helix-go/state"
+	"github.com/orbs-network/scribe/log"
 	"time"
 )
 
@@ -99,4 +100,5 @@ type Logger interface {
 	Debug(format string, args ...interface{})
 	Info(format string, args ...interface{})
 	Error(format string, args ...interface{})
+	ConsensusTrace(format string, fields ...*log.Field)
 }

--- a/services/logger/console_logger.go
+++ b/services/logger/console_logger.go
@@ -9,11 +9,17 @@ package logger
 import (
 	"fmt"
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/scribe/log"
 )
 
+// Deprecated; use LHLogger wrapping Scribe
 type ConsoleLogger struct {
 	level LogLevel
 	uid   string
+}
+
+func (l *ConsoleLogger) ConsensusTrace(format string, fields ...*log.Field) {
+	l.Debug(format) // this is shit, but the whole class needs to go
 }
 
 func (l *ConsoleLogger) Debug(format string, args ...interface{}) {

--- a/services/logger/logger_context.go
+++ b/services/logger/logger_context.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
 	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
 	"github.com/orbs-network/lean-helix-go/state"
+	"github.com/orbs-network/scribe/log"
 	"math"
 	"time"
 )
@@ -104,6 +105,14 @@ func (l *lhLogger) Error(format string, args ...interface{}) {
 	l.log(LOG_LEVEL_ERROR, format, args...)
 }
 
+func (l *lhLogger) ConsensusTrace(msg string, err error, fields ...*log.Field) {
+	fields = append(fields, log.Uint64("block-height", uint64(l.state.Height())), log.Uint64("view", uint64(l.state.View())))
+	if err != nil {
+		fields = append(fields, log.Error(err))
+	}
+	l.externalLogger.ConsensusTrace(msg, fields...)
+}
+
 func NewLhLogger(config *interfaces.Config, state *state.State) LHLogger {
 	var logger interfaces.Logger
 	if config.Logger == nil {
@@ -134,6 +143,7 @@ type LHLogger interface {
 	Info(format string, args ...interface{})
 	Error(format string, args ...interface{})
 	ExternalLogger() interfaces.Logger
+	ConsensusTrace(msg string, err error, fields ...*log.Field)
 }
 
 func LC(h primitives.BlockHeight, v primitives.View, id primitives.MemberId) *_LC {

--- a/services/logger/silent_logger.go
+++ b/services/logger/silent_logger.go
@@ -8,6 +8,7 @@ package logger
 
 import (
 	"github.com/orbs-network/lean-helix-go/services/interfaces"
+	"github.com/orbs-network/scribe/log"
 )
 
 type SilentLogger struct {
@@ -15,6 +16,9 @@ type SilentLogger struct {
 
 func NewSilentLogger() interfaces.Logger {
 	return &SilentLogger{}
+}
+
+func (l *SilentLogger) ConsensusTrace(format string, fields ...*log.Field) {
 }
 
 func (*SilentLogger) Debug(format string, args ...interface{}) {

--- a/services/rawmessagesfilter/raw_message_filter.go
+++ b/services/rawmessagesfilter/raw_message_filter.go
@@ -12,6 +12,7 @@ import (
 	"github.com/orbs-network/lean-helix-go/services/termincommittee"
 	"github.com/orbs-network/lean-helix-go/spec/types/go/primitives"
 	"github.com/orbs-network/lean-helix-go/state"
+	"github.com/orbs-network/scribe/log"
 )
 
 type RawMessageFilter struct {
@@ -39,6 +40,7 @@ func NewConsensusMessageFilter(instanceId primitives.InstanceId, myMemberId prim
 // TODO Consider passing ConsensusMessage instead of *interfaces.ConsensusRawMessage
 func (f *RawMessageFilter) HandleConsensusRawMessage(rawMessage *interfaces.ConsensusRawMessage) {
 	message := interfaces.ToConsensusMessage(rawMessage)
+
 	if f.isMyMessage(message) {
 		f.logger.Debug("LHFILTER IGNORING RECEIVED %s with H=%d V=%d sender=%s IGNORING message I sent", message.MessageType(), message.BlockHeight(), message.View(), termincommittee.Str(message.SenderMemberId()))
 		return
@@ -100,6 +102,7 @@ func (f *RawMessageFilter) processConsensusMessage(message interfaces.ConsensusM
 		return
 	}
 
+	f.logger.ConsensusTrace("received consensus message", nil, log.Stringable("message-type", message.MessageType()), log.Stringable("sender", message.SenderMemberId()))
 	if err := f.consensusMessagesHandler.HandleConsensusMessage(message); err != nil {
 		f.logger.Info("LHFILTER LHMSG Failed in HandleConsensusMessage(): %s", err)
 	}


### PR DESCRIPTION
This PR adds semantic (structured) log messages to allow visualizing and monitoring the consensus state across a virtual chain