### PR TITLE
remove recipients in broadcast

### DIFF
--- a/services/termincommittee/term_in_committee.go
+++ b/services/termincommittee/term_in_committee.go
@@ -361,7 +361,7 @@ func (tic *TermInCommittee) sendConsensusMessage(message interfaces.ConsensusMes
 	tic.logger.Debug("LHMSG SEND sendConsensusMessage() target=ALL, msgType=%v", message.MessageType())
 	rawMessage := interfaces.CreateConsensusRawMessage(message)
 	err := tic.communication.SendConsensusMessage(context.TODO(), tic.otherCommitteeMemberIds, rawMessage)
-	tic.logger.ConsensusTrace("sent consensus message", err, log.Stringable("message-type", message.MessageType()), log.StringableSlice("recipients", tic.otherCommitteeMemberIds))
+	tic.logger.ConsensusTrace("sent consensus message to all other members", err, log.Stringable("message-type", message.MessageType()))
 	return err
 }
 


### PR DESCRIPTION
 remove list of recipients in broadcast can be deduced from current committee members (note: on send to specific member, recipient is logged)